### PR TITLE
Add license and repository metadata for open-source readiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thanks for contributing to SQL MCP Server.
+
+## Before you start
+
+- Open an issue for larger features, security-sensitive changes, or behavior changes.
+- Keep pull requests focused and small when possible.
+- Prefer documentation updates when changing behavior or configuration.
+
+## Development
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Pull requests
+
+Please include:
+
+- a clear summary of the problem being solved
+- implementation notes and any tradeoffs
+- documentation updates when user-facing behavior changes
+
+## License
+
+By submitting a contribution, you agree that your contribution will be licensed under the MIT License used by this repository.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 rapha4lx
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Servidor MCP em Python para expor consultas seguras de leitura a bancos de dados SQL (Postgres, MySQL, SQLite, etc.) como tools para agentes.
 
+## Project status and support
+
+Este projeto está sendo preparado para uso open source. Issues e pull requests são bem-vindos, mas mudanças grandes devem começar por uma issue para alinhar escopo, segurança e compatibilidade.
+
 ## O que ele expõe
 
 - `create_session`: cria uma token configurando a URI do banco dinamicamente bem como definindo as flags de permissões (`allow_read`, `allow_insert`, etc) desejadas.
@@ -311,3 +315,9 @@ As tools de leitura aceitam `session_token`:
 
 > [!CAUTION]
 > Dando os comandos ao LLM e o acesso a flags `allow_delete` ou `allow_drop`, ele pode de fato resetar infraestruturas inteiras no provedor em caso de problemas não supervisionados. Esteja ciente ao permitir conexões Master ou conceder essas flags globais que alteram o escopo.
+
+## License and contributions
+
+Este projeto está licenciado sob a licença MIT. Veja [`LICENSE`](./LICENSE).
+
+Ao contribuir, você concorda que suas contribuições serão distribuídas sob a mesma licença do projeto. Para mudanças maiores, abra uma issue antes de começar a implementação para alinhar escopo e impacto.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,24 @@
 name = "sql-mcp-server"
 version = "0.1.0"
 description = "MCP server to expose safe SQL databases read tools to agent clients."
+readme = "README.md"
+license = { text = "MIT" }
 requires-python = ">=3.11"
 dependencies = [
   "mcp>=1.9.0",
   "python-dotenv>=1.0.1",
   "sqlalchemy>=2.0.0",
 ]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/rapha4lx/mcp"
+Issues = "https://github.com/rapha4lx/mcp/issues"
 
 [project.scripts]
 sql-mcp-server = "sql_mcp_server.server:main"


### PR DESCRIPTION
Closes #1

## Summary
- add MIT license
- add package license metadata and project URLs in `pyproject.toml`
- document project status, license, and contribution expectations in `README.md`
- add a minimal `CONTRIBUTING.md`

## Notes
This addresses the core open-source metadata gap so external users can determine reuse permissions and contribution expectations clearly.